### PR TITLE
Removed "addSubdomain" from list of required API permissons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,6 @@ Usage
 -----
 The plugin requires the following permissions enabled for your Loopia API user:
 
-- addSubdomain (I can't test if it's required)
 - addZoneRecord
 - getZoneRecords
 - removeSubdomain


### PR DESCRIPTION
I just tried creating a new Loopia API user without
this permission and it works just fine.