### PR TITLE
Add third-party lib for splitting domains

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "acme>=1.8.0",
         "certbot>=1.7.0",
         "loopialib>=0.2.0",
+        "tldextract>=3.3.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
The lib tldextract is now used instead of the
split_domain function from loopialib.

tldextract is well maintained and should be
more future-proof.

Solves https://github.com/runfalk/certbot-dns-loopia/issues/31